### PR TITLE
Fix CSV formula injection (#11) and run-tests.sh stale-container bug

### DIFF
--- a/frontend/src/lib/csv.test.ts
+++ b/frontend/src/lib/csv.test.ts
@@ -43,4 +43,33 @@ describe('toCsv', () => {
     const out = toCsv(['x'], [['plain']])
     expect(out).toBe(`${BOM}x\r\nplain`)
   })
+
+  it('neutralizes a formula-injection payload starting with =', () => {
+    const out = toCsv(['title'], [[`=cmd|'/c calc'!A1`]])
+    expect(out).toBe(`${BOM}title\r\n"'=cmd|'/c calc'!A1"`)
+  })
+
+  it('neutralizes every formula trigger (+ - @ tab CR)', () => {
+    for (const trigger of ['+', '-', '@', '\t', '\r']) {
+      const out = toCsv(['x'], [[`${trigger}SUM(A1)`]])
+      const field = out.slice(BOM.length).split('\r\n')[1]
+      expect(field).toBe(`"'${trigger}SUM(A1)"`)
+    }
+  })
+
+  it('never lets a formula cell reach the output with a bare leading trigger', () => {
+    const out = toCsv(['a', 'b'], [['=WEBSERVICE("http://x")', 'safe']])
+    // No field may begin (start-of-record or after a comma) with a bare `=`.
+    expect(out).not.toMatch(/(^|,)=/m)
+  })
+
+  it('does not neutralize a negative number', () => {
+    const out = toCsv(['amount'], [[-5], [-3.5]])
+    expect(out).toBe(`${BOM}amount\r\n-5\r\n-3.5`)
+  })
+
+  it('leaves an interior = untouched and unquoted', () => {
+    const out = toCsv(['x'], [['a=b']])
+    expect(out).toBe(`${BOM}x\r\na=b`)
+  })
 })

--- a/frontend/src/lib/csv.ts
+++ b/frontend/src/lib/csv.ts
@@ -3,14 +3,22 @@ export type CsvCell = string | number | null | undefined
 // Excel only auto-detects UTF-8 when the file starts with a byte-order mark.
 const UTF8_BOM = '﻿'
 
-/** Escape a single field per RFC 4180: quote when it contains `,` `"` or a newline. */
+/**
+ * Escape a single field per RFC 4180 (quote when it contains `,` `"` or a
+ * newline) and neutralize spreadsheet formula injection (CWE-1236): a string
+ * cell whose first character is a formula trigger (`=` `+` `-` `@` tab CR) is
+ * prefixed with a single quote and quoted, so a spreadsheet renders it as
+ * literal text instead of evaluating it. Numbers are program-generated and pass
+ * through untouched (avoids corrupting negative values like `-5`).
+ */
 function escapeCell(cell: CsvCell): string {
   if (cell === null || cell === undefined) return ''
-  const s = String(cell)
-  if (/[",\r\n]/.test(s)) {
-    return `"${s.replace(/"/g, '""')}"`
-  }
-  return s
+  if (typeof cell === 'number') return String(cell)
+  const s = cell
+  const dangerous = /^[=+\-@\t\r]/.test(s)
+  const needsQuote = dangerous || /[",\r\n]/.test(s)
+  const v = dangerous ? `'${s}` : s
+  return needsQuote ? `"${v.replace(/"/g, '""')}"` : v
 }
 
 /**

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,13 +12,21 @@ cleanup() {
     echo "Cleaning up test infrastructure..."
     # Always return to project root before running docker compose
     cd "$SCRIPT_DIR"
-    # Always specify project gracefully to avoid matching global compose
-    docker compose -f docker-compose.dev.yml stop db rustfs
+    # `down` (not `stop`) removes the containers so the next run can recreate
+    # them with their port mappings. Leaving stopped containers behind makes
+    # `up` fail with "name already in use" under podman-compose, and the
+    # recreated container loses its published host ports. Named volumes persist.
+    docker compose -f docker-compose.dev.yml down
     echo "Cleanup complete."
 }
 
 # Register the cleanup function to be called on the EXIT signal (whether success or failure)
 trap cleanup EXIT
+
+# Remove any containers left over from a previous interrupted run, otherwise
+# `up` may reuse a stale container that has no published host ports.
+echo "Clearing any stale test infrastructure..."
+docker compose -f docker-compose.dev.yml down --remove-orphans 2>/dev/null || true
 
 echo "Starting test infrastructure..."
 docker compose -f docker-compose.dev.yml up -d db rustfs


### PR DESCRIPTION
## Summary

Fixes two issues:

### 1. CSV formula injection in Finance export (closes #11, CWE-1236)

`frontend/src/lib/csv.ts` `escapeCell()` applied only RFC-4180 quoting, which does **not** stop a spreadsheet from evaluating a cell like `=cmd|'/c calc'!A1` (the app strips the surrounding quotes on import, then evaluates). Any authenticated `USER` (self-registerable via public `POST /api/auth/register`) could plant a payload in a free-text field; `GET /api/finance/history` exports requests in every state, so a `FINANCIAL_ADMIN` opening the `.csv` would trigger it — worst case RCE (Excel/Windows DDE), elsewhere SSRF/exfil (`WEBSERVICE`, `IMPORTDATA`).

**Fix:** neutralize string cells whose first char is a formula trigger (`=` `+` `-` `@` tab CR) by prefixing a single quote and quoting the field. Numbers short-circuit before the check, so program-generated values like a negative `amount` (`-5`) are **not** corrupted — a refinement over the regex proposed in the issue, which would have mangled negative numbers.

### 2. `run-tests.sh` stale-container bug

Cleanup used `docker compose ... stop`, which under podman-compose leaves stopped containers behind. The next run's `up -d` then silently reused a `db` container with **no published host port** (`5432/tcp` instead of `0.0.0.0:5432->5432/tcp`), so host-side Prisma failed with `P1001: Can't reach database server at 127.0.0.1:5432` before any tests ran.

**Fix:** use `docker compose down` in cleanup (removes containers; named data volumes persist) and add a pre-run `down --remove-orphans` to clear leftovers from an interrupted run.

## Test plan

- `frontend/src/lib/csv.test.ts`: added regression tests for each formula trigger, the no-bare-leading-trigger invariant, negative-number preservation, and interior `=`.
- `./run-tests.sh` now runs to completion: **backend 164 passed / 0 failed**, **frontend 158 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CSV export security to prevent formula injection attacks when opening exported data in spreadsheet applications.

* **Tests**
  * Expanded test coverage for CSV safety, validating formula-injection neutralization across edge cases.

* **Chores**
  * Improved Docker infrastructure cleanup processes for the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->